### PR TITLE
feat: add chart hooks to migration-job template for app chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+.idea/

--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -12,9 +12,9 @@ spec:
       annotations:
       # This is what defines this resource as a hook. Without this line, the
       # job is considered part of the release.
-      "helm.sh/hook": post-install
+      "helm.sh/hook": pre-install
       "helm.sh/hook-weight": "-5"
-      "helm.sh/hook-delete-policy": hook-succeeded
+      "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
       {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -10,7 +10,12 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+      # This is what defines this resource as a hook. Without this line, the
+      # job is considered part of the release.
+      "helm.sh/hook": post-install
+      "helm.sh/hook-weight": "-5"
+      "helm.sh/hook-delete-policy": hook-succeeded
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
The current migration-job template does not clean up post the job completion. During app redeployments, this poses an issue, and one has to manually delete the completed migration job.

This change would clear the resource once the migration is done successfully.
Resolves issue - https://github.com/odpf/charts/issues/38