### PR TITLE
feat: restart app deployment on configmap change

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Currently, whenever there is a configmap change, the app deployment is not done automatically since the deployment spec itself didn't change. One has to intervene manually to do a rollout restart of the pods. 

This change will resolve that issue by taking the `sha256sum` of configmap which changes the deployment spec whenever there is a configmap change.