### PR TITLE
feat(meteor): add meteor's templating feature

### DIFF
--- a/stable/meteor/Chart.yaml
+++ b/stable/meteor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.3
+version: 0.1.4
 description: A Helm chart for Meteor (github.com/odpf/meteor)
 name: meteor
-appVersion: "v0.1.0"
+appVersion: "v0.2.3"

--- a/stable/meteor/README.md
+++ b/stable/meteor/README.md
@@ -63,6 +63,38 @@ recipes:
       name: console
 ```
 
+### Using recipe_template values
+```
+recipe_template:
+  enabled: false
+  template: |-
+    name: {{ .FileName }}
+    source:
+      type: bigquery
+      config:
+        project_id: {{ .FileName }}
+        service_account_json: |-
+          {"some": "service-account"}
+    processors:
+      - name: enrich
+        config:
+          company: {{ .Data.company }}
+    sinks:
+      - name: columbus
+        config:
+          host: "http://columbus.example.com"
+          type: {{ .columbus_type }}
+  data: |-
+    - FileName: my-project-A
+      Data:
+        company: odpf
+        columbus_type: table
+    - FileName: my-project-B
+      Data:
+        company: johndoe
+        columbus_type: dashboard
+```
+
 ---
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/meteor/templates/job.yaml
+++ b/stable/meteor/templates/job.yaml
@@ -35,6 +35,21 @@ spec:
                   name: "{{ include "meteor.name" . }}-variables-configmap"
               - secretRef:
                   name: "{{ include "meteor.name" . }}-secret"
+          {{- if .Values.recipe_template.enabled }}
+          - name: "{{ include "meteor.name" . }}-template"
+            image: "{{ required `image.repository is required` .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            command: ["/bin/sh","-c"]
+            args: ["meteor gen /opt/template/template.yaml -d /opt/template/template_data.yaml -o /opt/template/output; meteor run /opt/template/output"]
+            volumeMounts:
+              - name: "{{ include "meteor.name" . }}-template-volume"
+                mountPath: /opt/template
+            envFrom:
+              - configMapRef:
+                  name: "{{ include "meteor.name" . }}-variables-configmap"
+              - secretRef:
+                  name: "{{ include "meteor.name" . }}-secret"
+          {{- end }}
           restartPolicy: Never
           volumes:
             - name: "{{ include "meteor.name" . }}-volume"
@@ -45,3 +60,13 @@ spec:
                 - key: {{ $k }}
                   path: {{ $k }}
                 {{- end }}
+            {{- if .Values.recipe_template.enabled }}
+            - name: "{{ include "meteor.name" . }}-template-volume"
+              configMap:
+                name: "{{ include "meteor.name" . }}-recipe-template-configmap"
+                items:
+                  - key: template.yaml
+                    path: template.yaml
+                  - key: template_data.yaml
+                    path: template_data.yaml
+            {{- end }}

--- a/stable/meteor/templates/recipe-template-configmap.yaml
+++ b/stable/meteor/templates/recipe-template-configmap.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.recipe_template.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "meteor.name" . }}-recipe-template-configmap"
+  namespace: {{ include "meteor.namespace" . }}
+data:
+  template.yaml: |-
+{{ .Values.recipe_template.template | indent 4 }}
+  template_data.yaml: |-
+{{ .Values.recipe_template.data | indent 4 }}
+{{- end }}

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -19,3 +19,34 @@ secretConfig: {}
 #         foo: "bar"
 #     sinks:
 #       - name: console
+
+
+# sample recipe template usage
+recipe_template:
+  enabled: false
+  # template: |-
+  #   name: {{ .FileName }}
+  #   source:
+  #     type: bigquery
+  #     config:
+  #       project_id: {{ .FileName }}
+  #       service_account_json: |-
+  #         {"some": "service-account"}
+  #   processors:
+  #     - name: enrich
+  #       config:
+  #         company: {{ .Data.company }}
+  #   sinks:
+  #     - name: columbus
+  #       config:
+  #         host: "http://columbus.example.com"
+  #         type: {{ .columbus_type }}
+  # data: |-
+  #   - FileName: my-project-A
+  #     Data:
+  #       company: odpf
+  #       columbus_type: table
+  #   - FileName: my-project-B
+  #     Data:
+  #       company: johndoe
+  #       columbus_type: dashboard


### PR DESCRIPTION
## New values
**values.yaml**
```
...other values
recipe_template:
  enabled: false
  template: <recipe-template-in-yaml>
  data: <template-data-in-yaml>
```
**sample**
```
recipe_template:
  enabled: false
  template: |-
    name: {{ .FileName }}
    source:
      type: bigquery
      config:
        project_id: {{ .FileName }}
        service_account_json: |-
          {"some": "service-account"}
    processors:
      - name: enrich
        config:
          company: {{ .Data.company }}
    sinks:
      - name: columbus
        config:
          host: "http://columbus.example.com"
          type: {{ .columbus_type }}
  data: |-
    - FileName: my-project-A
      Data:
        company: odpf
        columbus_type: table
    - FileName: my-project-B
      Data:
        company: johndoe
        columbus_type: dashboard
```

## Output
This will translate to:
1. new configmap that will store this template and template data
2. new container in the pod to run this template
3. the new configmap will be injected as files via volume to the new container
