### PR TITLE
feat(app): add telegraf sidecar

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2

--- a/stable/app/README.md
+++ b/stable/app/README.md
@@ -80,6 +80,17 @@ The following table lists the configurable parameters of the Siren chart and the
 | migration.command                     | list   | `[]`                                                                                       |                                                                      |
 | migration.args                        | list   | `[]`                
 |                                                                      |
+| telegraf.enabled                      | bool   | `false`                
+|                                                                      |
+| telegraf.command                      | list   | `["telegraf"]`                
+|                                                                      |
+| telegraf.args                         | list   | `[]`                
+|                                                                      |
+| telegraf.containerPort                | int    | `8125`                
+|                                                                      |
+| telegraf.protocol                     | string | `UDP`                
+|                                                                      |
+| telegraf.config                       | string | `""`                | telegraf config file content |
 
 ---
 

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -11,11 +11,14 @@ spec:
       {{- include "app.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}}
+        {{- if .Values.telegraf.enabled }}
+        checksum/telegraf-config: {{ include (print $.Template.BasePath "/telegraf-configmap.yaml") . | sha256sum }}}
+        {{- end }}
+{{- with .Values.podAnnotations }}
+{{- toYaml . | nindent 8 }}
+{{- end }}
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}
     spec:

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -56,9 +56,34 @@ spec:
             - secretRef:
                 name: "{{ template "app.fullname" . }}-secret"
          {{- end }}
+        {{- if .Values.telegraf.enabled }}
+        - name: telegraf-sidecar
+          image: {{ .Values.telegraf.image }}
+          args:
+            {{- range .Values.telegraf.args }}
+            - {{ . }}
+            {{- end }}
+          command:
+            {{- range .Values.telegraf.command }}
+            - {{ . }}
+            {{- end }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: {{ .Values.telegraf.containerPort }}
+              name: http
+              protocol: {{ .Values.telegraf.protocol }}
+          volumeMounts:
+            - name: telegraf-conf
+              mountPath: /etc/telegraf/
+        {{- end }}
       volumes:
         {{- range $volume := .Values.volumes }}
         - {{- toYaml $volume | nindent 12 }}
+        {{- end }}
+        {{- if .Values.telegraf.enabled }}
+        - name: telegraf-conf
+          configMap:
+            name: {{ template "app.fullname" . }}-telegraf
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -12,13 +12,13 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}}
+        checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.telegraf.enabled }}
-        checksum/telegraf-config: {{ include (print $.Template.BasePath "/telegraf-configmap.yaml") . | sha256sum }}}
+        checksum/telegraf-config: {{ include (print $.Template.BasePath "/telegraf-configmap.yaml") . | sha256sum }}
         {{- end }}
-{{- with .Values.podAnnotations }}
-{{- toYaml . | nindent 8 }}
-{{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}
     spec:

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -15,7 +15,7 @@ spec:
       "helm.sh/hook": pre-install
       "helm.sh/hook-weight": "-5"
       "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
-      {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -8,13 +8,13 @@ metadata:
 spec:
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
       # This is what defines this resource as a hook. Without this line, the
       # job is considered part of the release.
       "helm.sh/hook": pre-install
       "helm.sh/hook-weight": "-5"
       "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+      {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       labels:

--- a/stable/app/templates/telegraf-configmap.yaml
+++ b/stable/app/templates/telegraf-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.telegraf.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "app.fullname" . }}-telegraf
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+data:
+  telegraf.conf: |-
+{{ .Values.telegraf.config | indent 4 }}
+{{- end }}

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -118,3 +118,13 @@ secretConfig: {}
   # DB_USER: ""
   # DB_PASSWORD: ""
   # DB_PORT: 5432
+
+telegraf:
+  enabled: false
+  image: telegraf:1.19.3-alpine
+  config: ~ # telegraf config
+  containerPort: 8125
+  protocol: UDP
+  args:
+  command:
+    - telegraf


### PR DESCRIPTION
Add telegraf sidecar to base `app` chart. With below configuration

```
telegraf:
  enabled: false
  image: telegraf:1.19.3-alpine
  config: ~ # telegraf config
  containerPort: 8125
  protocol: UDP
  args:
  command:
    - telegraf
```