### PR TITLE
fix: create secrets and configmap before migration job

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4

--- a/stable/app/templates/configmap.yaml
+++ b/stable/app/templates/configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ include "app.fullname" . }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
 data:
   {{- range $k, $v := .Values.config }}
   {{ $k }}: {{ $v | quote }}

--- a/stable/app/templates/configmap.yaml
+++ b/stable/app/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: "{{ include "app.fullname" . }}"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
 data:
   {{- range $k, $v := .Values.config }}

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
     {{- with .Values.podAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -9,7 +9,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation
     {{- with .Values.podAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/stable/app/templates/migration-job.yaml
+++ b/stable/app/templates/migration-job.yaml
@@ -9,7 +9,6 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
     {{- with .Values.podAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/stable/app/templates/secret.yaml
+++ b/stable/app/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "app.fullname" . }}-secret
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
   labels:
     {{- include "app.labels" . | nindent 4 }}

--- a/stable/app/templates/secret.yaml
+++ b/stable/app/templates/secret.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ template "app.fullname" . }}-secret
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
   labels:
     {{- include "app.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
Why this fix is needed?
   Currently some of the migration job are dependent on ConfigMaps and secret. And since the migration job has `pre-install` helm hook, the configmaps and secret by default are created during the `install` phase
   
   So currently while deploying `Compass` chart in a fresh state with migration job enabled it fails with error `CreateContainerConfigError` because of `configMap` not being present. 
   
What does this PR do?
 - Creates configMap and secrets before job in pre-install phase with hook weight `-5`
 - Remove hook-weight on migration-job, so the `default` is `0`
 - Add pre-upgrade hook for migration job/configMap/secrets, so migration script executes during helm upgrades as well
 - Add hook delete policy: `before-hook-creation`, so that the job logs can be viewed. (With `hook-succeeded` or `hook-failed` the job and pod destroyed on success or failure. We will not be able to view logs when this happens)
 
Hook weight decides the order of resource creation in pre-install phase negative to positive