### PR TITLE
feat(meteor): allow updating cronjob concurrency policy

### DIFF
--- a/stable/meteor/Chart.yaml
+++ b/stable/meteor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.3
+version: 0.1.4
 description: A Helm chart for Meteor (github.com/odpf/meteor)
 name: meteor
-appVersion: "v0.1.0"
+appVersion: "v0.5.1"

--- a/stable/meteor/README.md
+++ b/stable/meteor/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters of the Meteor chart and th
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
 | schedule | string | `"0 1 * * *"`  | https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule |
-| concurrencyPolicy | string | `"Allow"`  | https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy |
+| concurrencyPolicy | string | `"Forbid"`  | https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy |
 | recipes | object {\[filename\]: \[content\]} | [example](#sample-recipes-usage)  |  |
 | namespace | string | `-` | to override release namespace |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/meteor/README.md
+++ b/stable/meteor/README.md
@@ -42,7 +42,8 @@ The following table lists the configurable parameters of the Meteor chart and th
 
 | Key | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| schedule | string | `"0 1 * * *"`  | cronjob schedule |
+| schedule | string | `"0 1 * * *"`  | https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule |
+| concurrencyPolicy | string | `"Allow"`  | https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy |
 | recipes | object {\[filename\]: \[content\]} | [example](#sample-recipes-usage)  |  |
 | namespace | string | `-` | to override release namespace |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -9,6 +9,7 @@ metadata:
 {{- end }}
 spec:
   schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
   jobTemplate:
     spec:
       backoffLimit: 4

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -1,5 +1,5 @@
 schedule: "0 1 * * *"
-concurrencyPolicy: "Allow"
+concurrencyPolicy: "Forbid"
 image:
   # [required] repository where meteor Docker image is available
   repository: odpf/meteor

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -1,8 +1,9 @@
 schedule: "0 1 * * *"
+concurrencyPolicy: "Allow"
 image:
   # [required] repository where meteor Docker image is available
   repository: odpf/meteor
-  tag: latest
+  tag: "0.5.1"
   pullPolicy: IfNotPresent
 labels: {"application":"meteor"}
 


### PR DESCRIPTION
New configuration to modify k8s cronjob's concurreny policy
Ref: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy

```
concurrencyPolicy: "Forbid"
```