### PR TITLE
fix(app): update cron job name in app chart

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1

--- a/stable/app/templates/cron.yaml
+++ b/stable/app/templates/cron.yaml
@@ -6,7 +6,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ $fullName | trunc 29 }}-{{ $i }}-{{ $job.name | trunc 29}}"
+  name: "{{ $fullName | trunc 24 }}-{{ $i }}-{{ $job.name | trunc 24}}"
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- $appLabels | nindent 4 }}


### PR DESCRIPTION
* reduce the default length to less than or equal to 52 chars

closes #73 