### PR TITLE
feat(meteor): support kafka meteor extractor for TLS enabled kafka

### DIFF
--- a/stable/meteor/Chart.yaml
+++ b/stable/meteor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.5
+version: 0.1.6
 description: A Helm chart for Meteor (github.com/odpf/meteor)
 name: meteor
 appVersion: "v0.5.1"

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -31,6 +31,10 @@ spec:
             volumeMounts:
               - name: "{{ include "meteor.name" . }}-volume"
                 mountPath: /opt/recipes
+              {{- range $k, $v := .Values.ssl_secrets }}
+              - name: {{ $v }}
+                mountPath: {{ printf "%s/%s" "/etc/secret" $v }}
+              {{- end }}
             envFrom:
               - configMapRef:
                   name: "{{ include "meteor.name" . }}-variables-configmap"
@@ -48,3 +52,10 @@ spec:
                 - key: {{ $k }}
                   path: {{ $k }}
                 {{- end }}
+            {{- range $k, $v := .Values.ssl_secrets }}
+            - name: {{ $v }}
+              secret:
+                defaultMode: 420
+                optional: true
+                secretName: {{ $v }}
+            {{- end }}

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -9,6 +9,7 @@ labels: {"application":"meteor"}
 
 config: {}
 secretConfig: {}
+# pass in secret names to be mounted to cronjob
 ssl_secrets: []
 
 # sample recipe usage

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -9,6 +9,7 @@ labels: {"application":"meteor"}
 
 config: {}
 secretConfig: {}
+ssl_secrets: []
 
 # sample recipe usage
 # recipes:


### PR DESCRIPTION
This PR adds feature to pass in secret names and mount it to cronjob as volume.
The secret is created outside chart and passed in to chart for mounting to cronjob.

This allows to connect meteor to TLS enabled kafka clusters passing in client certificate, client key and CA certificate as part of secret to meteor job.